### PR TITLE
Limit schema_monkey to AR < 6

### DIFF
--- a/schema_monkey.gemspec
+++ b/schema_monkey.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.1.0"
-  spec.add_dependency "activerecord", ">= 4.2"
+  spec.add_dependency "activerecord", ">= 4.2", "< 6"
   spec.add_dependency "its-it"
   spec.add_dependency "modware", "~> 0.1"
 


### PR DESCRIPTION
This PR proactively limits `schema_monkey` to only work with AR 4.2+ and 5.x instead of allowing unbounded versions on the upper end.