### PR TITLE
Depend on `its-it` only for gem development.

### DIFF
--- a/lib/schema_monkey.rb
+++ b/lib/schema_monkey.rb
@@ -1,6 +1,5 @@
 require 'active_record'
 require 'active_support/core_ext/string'
-require 'its-it'
 require 'modware'
 
 require_relative "schema_monkey/active_record"

--- a/lib/schema_monkey/client.rb
+++ b/lib/schema_monkey/client.rb
@@ -35,7 +35,7 @@ module SchemaMonkey
       path = mod.to_s.sub(/^#{@root}::#{base}::/, '')
       if dbm
         path = path.split('::')
-        if (i = path.find_index(&it =~ /\b#{dbm}\b/i)) # delete first occurence
+        if (i = path.find_index { |it| it =~ /\b#{dbm}\b/i }) # delete first occurence
           path.delete_at i
         end
         path = path.join('::').gsub(/#{dbm}/i, dbm.to_s) # canonicalize case for things like PostgreSQLAdapter
@@ -56,8 +56,8 @@ module SchemaMonkey
 
       modules = []
       modules += Module.descendants(container, can_load: accept)
-      modules.select!(&it.to_s =~ accept) if accept
-      modules.reject!(&it.to_s =~ reject) if reject
+      modules.select! { |it| it.to_s =~ accept } if accept
+      modules.reject! { |it| it.to_s =~ reject } if reject
       modules
     end
 

--- a/lib/schema_monkey/module.rb
+++ b/lib/schema_monkey/module.rb
@@ -27,7 +27,7 @@ module SchemaMonkey
     def descendants(mod, can_load: nil)
       consts, auto = mod.constants.group_by{|c| !!mod.autoload?(c)}.values_at(false, true)
       consts ||= []
-      consts += auto.select &it.to_s =~ can_load if can_load and auto
+      consts += auto.select { |it| it.to_s =~ can_load } if can_load and auto
       children = consts.map{|c| mod.const_get(c) }.select { |obj|
         obj.is_a?(::Module) rescue nil
       }

--- a/lib/schema_monkey/monkey.rb
+++ b/lib/schema_monkey/monkey.rb
@@ -21,7 +21,7 @@ module SchemaMonkey
 
     def insert(dbm: nil)
       insert if dbm and not @inserted # first do all non-dbm-specific insertions
-      @client_map.values.each &it.insert(dbm: dbm)
+      @client_map.values.each { |it| it.insert(dbm: dbm) }
       @inserted = true
       @inserted_dbm = dbm if dbm
     end

--- a/schema_monkey.gemspec
+++ b/schema_monkey.gemspec
@@ -20,13 +20,13 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.1.0"
   spec.add_dependency "activerecord", ">= 4.2"
-  spec.add_dependency "its-it"
   spec.add_dependency "modware", "~> 0.1"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-given", "~> 3.6"
+  spec.add_development_dependency "its-it"
   spec.add_development_dependency "schema_dev", "~> 3.7"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "simplecov-gem-profile"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 
 require 'rspec'
 require 'rspec/given'
+require 'its-it'
 require 'active_record'
 require 'schema_monkey'
 require 'schema_dev/rspec'


### PR DESCRIPTION
This will help anyone who wants to use `schema_monkey`, but doesn't want the `its-it` Kernel methods.

The kernel methods are still available in the specs, which is convenient.

I couldn't get `schema_dev` running locally, so I'm leaning on Travis to run the specs here :disappointed:  ~~I'll fix any failures, and squash them into the one commit here.~~ Horray, no failures!