### PR TITLE
Fix minor error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ module PracticalJoker
     module Base
 
        def save(*args)
-         raise "April Fools!" if Time.now.yday == 31
+         raise "April Fools!" if Time.now.yday == 91
          super
        end
 


### PR DESCRIPTION
The yday for 4/1 is (in non-leap years) 91, not 31. (It's actually 92 in leap years, but no biggie.)